### PR TITLE
fix(calendar): Tweak monthsForLocale to consistently return list of m…

### DIFF
--- a/packages/calendar/index.tsx
+++ b/packages/calendar/index.tsx
@@ -81,7 +81,7 @@ export const monthsForLocale = (
     .format;
 
   return [...new Array(12).keys()].map((m) =>
-    format(new Date(Date.UTC(2021, m % 12)))
+    format(new Date(Date.UTC(2021, m, 2)))
   );
 };
 


### PR DESCRIPTION
…onths in correct order

## Description

Modified monthsForLocale function to always return months in correct order.

## Related Issues

Closes #133 

## Checklist

- [x ] My code follows the code style of this project.
- [x ] I have performed a self-review of my code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ x] New and existing tests pass locally with my changes.


## Additional Notes
When you create a date with only a year and month (e.g., new Date(Date.UTC(2021, 0)), it defaults to January 1, 2021.
But if your environment's default timezone is UTC-8 or less (e.g., America/Los_Angeles), then new Date(Date.UTC(2021, 0)) will actually be December 31, 2020, in local time.
So, formatting that date in your local timezone will show "December" instead of "January".

The fix:
 Always use the 2nd day of the month to avoid timezone issues:
Why this works:
By using the 2nd day of the month, you avoid the possibility of the date rolling back to the previous month in timezones behind UTC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of month name generation for different locales in the calendar display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->