### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/haydenbleasel/kibo/security/code-scanning/3](https://github.com/haydenbleasel/kibo/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the least privileges required. Based on the workflow's steps, the following permissions are necessary:
- `contents: read` for accessing the repository's contents (e.g., fetching tags, installing dependencies).
- `contents: write` for creating a release in the "Create Release" step.
- `packages: write` for publishing packages if required by `npx auto shipit`.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
