### PR TITLE
Fix button submit when use color-picker inside form

### DIFF
--- a/packages/color-picker/index.tsx
+++ b/packages/color-picker/index.tsx
@@ -300,6 +300,7 @@ export const ColorPickerEyeDropper = ({
       onClick={handleEyeDropper}
       size="icon"
       variant="outline"
+      type="button"
       {...props}
     >
       <PipetteIcon size={16} />


### PR DESCRIPTION
Fix button submitting form when use color-picker inside form, adding `type="button"` to `<Button />` component

## Description

This PR prevents the `<Button />` used in `ColorPickerEyeDropper` from submitting the parent `<form>` unexpectedly.  
When placed inside a form, a button without `type` defaults to `"submit"`, which was causing the form to be submitted when the EyeDropper was triggered.

The fix is a simple addition of `type="button"` to the Button props.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

Not applicable — behavior-level fix (form submission prevention).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the color picker’s eye dropper button to prevent unintended form submissions when used inside forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->