### PR TITLE
Fix font-family reference issue

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -2,7 +2,6 @@ import './global.css';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { Toaster } from '@repo/shadcn-ui/components/ui/sonner';
 import { TooltipProvider } from '@repo/shadcn-ui/components/ui/tooltip';
-import { cn } from '@repo/shadcn-ui/lib/utils';
 import { Analytics as VercelAnalytics } from '@vercel/analytics/react';
 import { RootProvider } from 'fumadocs-ui/provider';
 import type { ReactNode } from 'react';
@@ -15,8 +14,8 @@ type LayoutProps = {
 };
 
 const Layout = ({ children }: LayoutProps) => (
-  <html lang="en" suppressHydrationWarning>
-    <body className={cn('flex min-h-screen flex-col', fonts)}>
+  <html lang="en" className={fonts} suppressHydrationWarning>
+    <body className="flex min-h-screen flex-col">
       <ThemeProvider>
         <RootProvider>
           <TooltipProvider>{children}</TooltipProvider>


### PR DESCRIPTION
## Description

Certain preflight styles were returning invalid due to font-family reference issues. The references were occurring on `html` (`:root`), but the fonts were defined on the `body`.

Thanks to @wongjn for helping to pinpoint the root problem here in this related discussion:
https://discord.com/channels/486935104384532500/1392576461319438429

## Related Issues

_no related issue_

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] ~I have commented my code, particularly in hard-to-understand areas.~
- [x] I have updated the documentation, if necessary.
- [x] ~I have added tests that prove my fix is effective or my feature works.~
- [x] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

| Before | After |
|--------|--------|
| ![](https://github.com/user-attachments/assets/f042d7eb-5745-45e7-9a5b-ecc590a46a40) | ![](https://github.com/user-attachments/assets/1f43ffbb-0280-472a-99be-8fc5a5153593) | 

_the content in these screenshots has been altered for the sake of this example_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the way font styles are applied by moving the font-related class from the body to the html tag for improved structure and consistency. No visible changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->