### PR TITLE
feat: make preview content panels resizable

### DIFF
--- a/apps/docs/components/preview/content.tsx
+++ b/apps/docs/components/preview/content.tsx
@@ -1,14 +1,10 @@
 'use client';
 
 import {
-  TabsContent,
-} from '@repo/shadcn-ui/components/ui/tabs';
-import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from '@repo/shadcn-ui/components/ui/resizable';
-import { cn } from '@repo/shadcn-ui/lib/utils';
 import { PreviewRender } from './render';
 
 type PreviewContentProps = {
@@ -18,39 +14,31 @@ type PreviewContentProps = {
 
 export const PreviewContent = ({ Component, type }: PreviewContentProps) => {
   return (
-    <TabsContent
-      className={cn(
-        'not-fumadocs-codeblock size-full',
-        type === 'component' ? 'overflow-hidden' : 'overflow-auto'
-      )}
-      value="preview"
+    <ResizablePanelGroup 
+      direction="horizontal" 
+      className="size-full"
     >
-      <ResizablePanelGroup 
-        direction="horizontal" 
-        className="size-full"
+      <ResizablePanel
+        defaultSize={100}
+        minSize={40}
+        maxSize={100}
+        className="peer"
       >
-        <ResizablePanel
-          defaultSize={100}
-          minSize={40}
-          maxSize={100}
-          className="peer"
-        >
-          {type === 'block' ? (
+        {type === 'block' ? (
+          <Component />
+        ) : (
+          <PreviewRender>
             <Component />
-          ) : (
-            <PreviewRender>
-              <Component />
-            </PreviewRender>
-          )}
-        </ResizablePanel>
-        <ResizableHandle withHandle className="peer-data-[panel-size=100.0]:w-0" />
-        <ResizablePanel
-          defaultSize={0}
-          minSize={0}
-          maxSize={70}
-          className="bg-background border-none"
-        />
-      </ResizablePanelGroup>
-    </TabsContent>
+          </PreviewRender>
+        )}
+      </ResizablePanel>
+      <ResizableHandle withHandle className="peer-data-[panel-size=100.0]:w-0" />
+      <ResizablePanel
+        defaultSize={0}
+        minSize={0}
+        maxSize={70}
+        className="bg-background border-none"
+      />
+    </ResizablePanelGroup>
   );
 };

--- a/apps/docs/components/preview/index.tsx
+++ b/apps/docs/components/preview/index.tsx
@@ -96,7 +96,15 @@ export const Preview = async ({
         >
           <PreviewCode code={parsedCode} filename="index.tsx" language="tsx" />
         </TabsContent>
-        <PreviewContent Component={Component} type={type} />
+        <TabsContent
+          className={cn(
+            'not-fumadocs-codeblock size-full',
+            type === 'component' ? 'overflow-hidden' : 'overflow-auto'
+          )}
+          value="preview"
+        >
+          <PreviewContent Component={Component} type={type} />
+        </TabsContent>
       </Tabs>
     </div>
   );


### PR DESCRIPTION
## Description

This PR makes the Preview Content panels resizable. This helps with visualizing components in mobile layouts. 
- Used already existing shadcn resizable component from the codebase
- Added css styling to set the resizable handle width to zero to prevent border overlapping
- Refactored the `PreviewContent` into a `content.tsx` file to clean it up


https://github.com/user-attachments/assets/43e5b238-d4ed-4bf0-905b-f07ed8224c12

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new resizable preview panel for components and blocks, allowing users to adjust the layout interactively.
* **Refactor**
  * Consolidated preview rendering logic into a single, unified component for a more streamlined and consistent preview experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->