### PR TITLE
fix: make file uploads responsive for image-crop component

### DIFF
--- a/apps/docs/examples/image-crop-circular.tsx
+++ b/apps/docs/examples/image-crop-circular.tsx
@@ -33,7 +33,7 @@ const Example = () => {
     return (
       <Input
         accept="image/*"
-        className="w-fit"
+        className="w-fit max-w-full"
         onChange={handleFileChange}
         type="file"
       />

--- a/apps/docs/examples/image-crop-custom.tsx
+++ b/apps/docs/examples/image-crop-custom.tsx
@@ -32,7 +32,7 @@ const Example = () => {
     return (
       <Input
         accept="image/*"
-        className="w-fit"
+        className="w-fit max-w-full"
         onChange={handleFileChange}
         type="file"
       />

--- a/apps/docs/examples/image-crop.tsx
+++ b/apps/docs/examples/image-crop.tsx
@@ -33,7 +33,7 @@ const Example = () => {
     return (
       <Input
         accept="image/*"
-        className="w-fit"
+        className="w-fit max-w-full"
         onChange={handleFileChange}
         type="file"
       />


### PR DESCRIPTION
## Description

Adds CSS styling to make the file upload input responsive for image-crop component

## Screenshots
### Mobile
<img width="376" height="795" alt="image" src="https://github.com/user-attachments/assets/dbfbd19b-cac4-4703-a4ef-a8b900f26a84" />


## Related Issues

Closes #174 

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the styling of file input elements in image crop examples to better fit their container width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->