### PR TITLE
fix: missing scroll on preview blocks, pricing page responsiveness

### DIFF
--- a/apps/docs/components/preview/content.tsx
+++ b/apps/docs/components/preview/content.tsx
@@ -1,21 +1,24 @@
-'use client';
-
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from '@repo/shadcn-ui/components/ui/resizable';
+import { cn } from '@repo/shadcn-ui/lib/utils';
 import type { ReactNode } from 'react';
 
 type PreviewContentProps = {
   children: ReactNode;
+  type: 'component' | 'block';
 };
 
-export const PreviewContent = ({ children }: PreviewContentProps) => {
+export const PreviewContent = ({ children, type }: PreviewContentProps) => {
   return (
     <ResizablePanelGroup className="size-full" direction="horizontal">
       <ResizablePanel
-        className="peer"
+        className={cn(
+          'peer not-fumadocs-codeblock size-full',
+          type === 'component' ? 'overflow-hidden!' : 'overflow-auto!'
+        )}
         defaultSize={100}
         maxSize={100}
         minSize={40}

--- a/apps/docs/components/preview/index.tsx
+++ b/apps/docs/components/preview/index.tsx
@@ -104,7 +104,7 @@ export const Preview = async ({
           )}
           value="preview"
         >
-          <PreviewContent>
+          <PreviewContent type={type}>
             {type === 'block' ? (
               <Component />
             ) : (

--- a/apps/docs/examples/pricing.tsx
+++ b/apps/docs/examples/pricing.tsx
@@ -76,7 +76,7 @@ const Example = () => {
   const [frequency, setFrequency] = useState<string>('monthly');
 
   return (
-    <div className="not-prose flex flex-col gap-16 px-8 py-24 text-center">
+    <div className="not-prose flex flex-col gap-16 px-8 py-24 text-center @container">
       <div className="flex flex-col items-center justify-center gap-8">
         <h1 className="mb-0 text-balance font-medium text-5xl tracking-tighter!">
           Simple, transparent pricing
@@ -94,7 +94,7 @@ const Example = () => {
             </TabsTrigger>
           </TabsList>
         </Tabs>
-        <div className="mt-8 grid w-full max-w-4xl gap-4 lg:grid-cols-3">
+        <div className="mt-8 grid w-full max-w-4xl gap-4 @2xl:grid-cols-3">
           {plans.map((plan) => (
             <Card
               className={cn(


### PR DESCRIPTION
## Description

- Added few missing CSS props for scroll on the preview content component
- Changed the responsive check from viewport based to `@container` query for pricing page

## Screengrabs
### Before

https://github.com/user-attachments/assets/e9e485d9-9431-4818-a88e-7b9e1b636d77

### After

https://github.com/user-attachments/assets/d76ab713-66fc-43f5-aa16-a467c2f67c13

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced preview functionality by allowing different types ('component' or 'block'), improving contextual rendering in the preview tab.

* **Style**
  * Improved responsive design in the pricing example by updating container query classes and adjusting grid breakpoints for better layout adaptability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->