### PR TITLE
fix: sidebar scroll reset when navigating to new page

### DIFF
--- a/apps/docs/app/(docs)/[[...slug]]/page.tsx
+++ b/apps/docs/app/(docs)/[[...slug]]/page.tsx
@@ -1,4 +1,3 @@
-import { DocsLayout } from 'fumadocs-ui/layouts/notebook';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import {
   DocsBody,
@@ -11,7 +10,6 @@ import { notFound } from 'next/navigation';
 import { Installer } from '../../../components/installer';
 import { PoweredBy } from '../../../components/powered-by';
 import { Preview } from '../../../components/preview';
-import { baseOptions } from '../../../lib/layout.config';
 import { source } from '../../../lib/source';
 import Home from './(home)';
 
@@ -24,21 +22,7 @@ const Page = async (props: PageProps) => {
   const page = source.getPage(params.slug);
 
   if (!params.slug) {
-    return (
-      <DocsLayout
-        {...baseOptions}
-        containerProps={{ className: 'landing-page' }}
-        // Alternative: don't show the sidebar at all in the landing page on mobile.
-        // in this case, set:
-        // 1. in /(docs)/[[...slug]]/page.tsx: sidebar={{ hidden: true, collapsible: false }}
-        // 2. in /global.css: .landing-page #nd-subnav button[data-search] + button { @apply hidden; }
-        nav={{ ...baseOptions.nav, mode: 'top' }}
-        sidebar={{ hidden: false, collapsible: false }}
-        tree={source.pageTree}
-      >
-        <Home />
-      </DocsLayout>
-    );
+    return <Home />;
   }
 
   if (!page) {
@@ -48,50 +32,24 @@ const Page = async (props: PageProps) => {
   const MDX = page.data.body;
 
   return (
-    <DocsLayout
-      {...baseOptions}
-      nav={{
-        ...baseOptions.nav,
-        mode: 'top',
-      }}
-      sidebar={{
-        collapsible: false,
-        tabs: [
-          {
-            title: 'Docs',
-            url: '/docs',
-          },
-          {
-            title: 'Components',
-            url: '/components',
-          },
-          {
-            title: 'Blocks',
-            url: '/blocks',
-          },
-        ],
-      }}
-      tree={source.pageTree}
+    <DocsPage
+      full={page.data.full}
+      tableOfContent={{ style: 'clerk' }}
+      toc={page.data.toc}
     >
-      <DocsPage
-        full={page.data.full}
-        tableOfContent={{ style: 'clerk' }}
-        toc={page.data.toc}
-      >
-        <DocsTitle>{page.data.title}</DocsTitle>
-        <DocsDescription>{page.data.description}</DocsDescription>
-        <DocsBody>
-          <MDX
-            components={{
-              ...defaultMdxComponents,
-              Installer,
-              Preview,
-              PoweredBy,
-            }}
-          />
-        </DocsBody>
-      </DocsPage>
-    </DocsLayout>
+      <DocsTitle>{page.data.title}</DocsTitle>
+      <DocsDescription>{page.data.description}</DocsDescription>
+      <DocsBody>
+        <MDX
+          components={{
+            ...defaultMdxComponents,
+            Installer,
+            Preview,
+            PoweredBy,
+          }}
+        />
+      </DocsBody>
+    </DocsPage>
   );
 };
 

--- a/apps/docs/app/(docs)/layout.tsx
+++ b/apps/docs/app/(docs)/layout.tsx
@@ -1,0 +1,39 @@
+import { DocsLayout } from 'fumadocs-ui/layouts/notebook';
+import type { ReactNode } from 'react';
+import { ConditionalContainer } from '../../components/conditional-container';
+import { baseOptions } from '../../lib/layout.config';
+import { source } from '../../lib/source';
+
+export default function DocsRootLayout({ children }: { children: ReactNode }) {
+  return (
+    <ConditionalContainer>
+      <DocsLayout
+        {...baseOptions}
+        nav={{
+          ...baseOptions.nav,
+          mode: 'top',
+        }}
+        sidebar={{
+          collapsible: false,
+          tabs: [
+            {
+              title: 'Docs',
+              url: '/docs',
+            },
+            {
+              title: 'Components',
+              url: '/components',
+            },
+            {
+              title: 'Blocks',
+              url: '/blocks',
+            },
+          ],
+        }}
+        tree={source.pageTree}
+      >
+        {children}
+      </DocsLayout>
+    </ConditionalContainer>
+  );
+} 

--- a/apps/docs/components/conditional-container.tsx
+++ b/apps/docs/components/conditional-container.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+// Specifically used to handle the layout of the home page vs rest of the pages since all are rendered by the same layout
+export function ConditionalContainer({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const isHomePage = pathname === '/';
+  
+  return (
+    <div className={isHomePage ? 'landing-page' : ''}>
+      {children}
+    </div>
+  );
+} 


### PR DESCRIPTION
## Description

- Previously when navigating to a new component from sidebar, it would reset the scroll due to entire page being re-rendered.
- Moved the layout logic to a separate file and added helper client components to add css classnames for the landing page based on the pathname.

## Screengrabs
### Before

https://github.com/user-attachments/assets/d98fc0ff-0880-4639-b4c9-b1be2680d1fc


### After

https://github.com/user-attachments/assets/a1a7e169-c332-45d0-864e-29484e47de3a



## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new layout for documentation pages, featuring a sidebar with tabs for "Docs," "Components," and "Blocks."
  * Added a ConditionalContainer component to apply specific styling to the home page.

* **Refactor**
  * Simplified the layout structure for documentation pages by consolidating rendering logic and removing redundant wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->