### PR TITLE
fix for empty kanban column drag

### DIFF
--- a/packages/kanban/index.tsx
+++ b/packages/kanban/index.tsx
@@ -241,7 +241,10 @@ export const KanbanProvider = <
     }
 
     const activeColumn = activeItem.column;
-    const overColumn = overItem?.column || columns.find(_=>_.id===over.id)?.id || columns[0].id;
+    const overColumn =
+      overItem?.column ||
+      columns.find(col => col.id === over.id)?.id ||
+      columns[0]?.id;
 
     if (activeColumn !== overColumn) {
       let newData = [...data];


### PR DESCRIPTION
## Description

Please provide a brief description of the changes introduced in this pull request.

Fix for dropping items on an empty kanban column, which fails as it always expects an item in the column to drop before/after.

This change allows the overItem to be null and instead searches for the column using the drop target.

## Related Issues

Closes #197

## Checklist

- [ ] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop behavior in the Kanban board for smoother item movement between columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->