### PR TITLE
Fix spacing between shadcn/ui and components in hero section

### DIFF
--- a/apps/docs/app/(docs)/[[...slug]]/(home)/components/hero/index.tsx
+++ b/apps/docs/app/(docs)/[[...slug]]/(home)/components/hero/index.tsx
@@ -71,7 +71,7 @@ export const Hero = () => (
             />{' '}
             <span>shadcn/ui</span>
           </div>
-          components built with{' '}
+          &nbsp;components built with{' '}
           <div className="-space-x-2 -translate-y-1.5 md:-translate-y-2.5 inline-flex items-center justify-center">
             {icons.map((icon, index) => (
               <Tooltip key={icon.name}>

--- a/apps/docs/app/(docs)/[[...slug]]/(home)/components/hero/index.tsx
+++ b/apps/docs/app/(docs)/[[...slug]]/(home)/components/hero/index.tsx
@@ -70,8 +70,8 @@ export const Hero = () => (
               width={56}
             />{' '}
             <span>shadcn/ui</span>
-          </div>
-          &nbsp;components built with{' '}
+          </div>{' '}
+          components built with{' '}
           <div className="-space-x-2 -translate-y-1.5 md:-translate-y-2.5 inline-flex items-center justify-center">
             {icons.map((icon, index) => (
               <Tooltip key={icon.name}>


### PR DESCRIPTION
## Description

Added spacing between "shadcn/ui" and "components" text in the hero section for better readability.

This PR includes **two different approaches** for the maintainers to choose from:
- **Commit 1:** Single-line layout using non-breaking space (`&nbsp;`)
- **Commit 2:** Two-line layout with regular spacing (`{' '}`)

## Screenshots

**Before:** Text was touching without proper spacing
<img width="1380" height="420" alt="Before" src="https://github.com/user-attachments/assets/93bc5deb-f649-4f94-9326-a21144748e14" />

**Option 1 (Single line):**
<img width="1380" height="420" alt="Option 1 (Single line" src="https://github.com/user-attachments/assets/cbac719c-aa5c-4efa-812b-52a93d6efd8e" />

**Option 2 (Two lines):**
<img width="1380" height="420" alt="Option 2 (Two lines)" src="https://github.com/user-attachments/assets/f300f776-cf9c-4022-9ab0-5a5c8a863e59" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the hero section for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->