### PR TITLE
feat: add dark mode fix for color picker alpha component

### DIFF
--- a/packages/color-picker/index.tsx
+++ b/packages/color-picker/index.tsx
@@ -255,13 +255,9 @@ export const ColorPickerAlpha = ({
       {...props}
     >
       <Slider.Track
-        className="relative my-0.5 h-3 w-full grow rounded-full"
-        style={{
-          background:
-            'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMUlEQVQ4T2NkYGAQYcAP3uCTZhw1gGGYhAGBZIA/nYDCgBDAm9BGDWAAJyRCgLaBCAAgXwixzAS0pgAAAABJRU5ErkJggg==") left center',
-        }}
+        className="relative my-0.5 h-3 w-full grow rounded-full bg-[url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMUlEQVQ4T2NkYGAQYcAP3uCTZhw1gGGYhAGBZIA/nYDCgBDAm9BGDWAAJyRCgLaBCAAgXwixzAS0pgAAAABJRU5ErkJggg==')] bg-repeat-x bg-center dark:bg-[url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAALklEQVR4nGP8+vWrCAMewM3N/QafPBM+SWLAqAGDwQBGQgoIpZOB98KoAVQwAADxzQcSVIRCfQAAAABJRU5ErkJggg==')]"
       >
-        <div className="absolute inset-0 rounded-full bg-gradient-to-r from-transparent to-black/50" />
+        <div className="absolute inset-0 rounded-full bg-gradient-to-r from-transparent to-black/50 dark:to-white/50" />
         <Slider.Range className="absolute h-full rounded-full bg-transparent" />
       </Slider.Track>
       <Slider.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />


### PR DESCRIPTION
## Description

Added dark mode colored bg-image for `ColorPickerAlpha` component. Previously it was using the same styles and image as light mode and wasn't great.

## Screenshots

### Before
<img width="456" height="437" alt="image" src="https://github.com/user-attachments/assets/d829b44e-7a6e-458b-8fbd-63fb68898445" />

### After
<img width="430" height="449" alt="image" src="https://github.com/user-attachments/assets/b9677ffc-5e69-414f-8559-fd9bceac1c88" />

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Color Picker: Alpha slider track now adapts to dark mode for improved visibility and contrast.

- Style
  - Replaced inline background with theme-aware classes for more consistent rendering.
  - Updated gradient overlay on the alpha slider to enhance clarity across light and dark themes.
  - Visual polish with smoother, repeatable background for the slider track.
  - No changes to behavior or interactions; functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->