### PR TITLE
feat: add copy button to Source/Code panels for quick access

### DIFF
--- a/apps/docs/components/preview/code.tsx
+++ b/apps/docs/components/preview/code.tsx
@@ -5,6 +5,7 @@ import {
   CodeBlock,
   CodeBlockBody,
   CodeBlockContent,
+  CodeBlockCopyButton,
   CodeBlockItem,
   type CodeBlockProps,
 } from '@repo/code-block';
@@ -30,6 +31,9 @@ export const PreviewCode = ({ code, language, filename }: PreviewCodeProps) => {
       data={data}
       defaultValue={data[0].language}
     >
+      <div className="sticky top-0 z-1">
+        <CodeBlockCopyButton className="absolute top-1 right-1.5" />
+      </div>
       <CodeBlockBody>
         {(item) => (
           <CodeBlockItem key={item.language} value={item.language}>

--- a/apps/docs/components/preview/source.tsx
+++ b/apps/docs/components/preview/source.tsx
@@ -6,6 +6,7 @@ import {
   CodeBlock,
   CodeBlockBody,
   CodeBlockContent,
+  CodeBlockCopyButton,
   CodeBlockItem,
 } from '@repo/code-block';
 import {
@@ -34,9 +35,9 @@ export const PreviewSource = ({ source }: PreviewSourceProps) => (
             <span>{name}</span>
           </div>
         </AccordionTrigger>
-        <AccordionContent>
+        <AccordionContent className='overflow-visible' style={{ overflow: 'visible' }}>
           <CodeBlock
-            className="overflow-auto rounded-none border-none"
+            className="overflow-visible rounded-none border-none"
             data={[
               {
                 language: 'tsx',
@@ -45,7 +46,10 @@ export const PreviewSource = ({ source }: PreviewSourceProps) => (
               },
             ]}
             defaultValue="tsx"
-          >
+            >
+            <div className="sticky top-0 z-1">
+              <CodeBlockCopyButton className="absolute top-1 right-1.5" />
+            </div>
             <CodeBlockBody>
               {(item) => (
                 <CodeBlockItem key={item.language} value={item.language}>


### PR DESCRIPTION
## Description

- Added copy button to the Code and Source sections of the component to be able to quickly copy samples and try it out.
- Added `overflow-visible` styles to make it sticky to the scroll container while reading code

Shadcn code sections also have similar copy button and my hunch is they owe to the success of the library (as a manual lover)!!

## Screengrab

https://github.com/user-attachments/assets/caa13955-ce35-4949-bdeb-06a6b0674656

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a copy-to-clipboard button to code blocks in Preview and Source views. The button appears at the top-right and stays visible while scrolling for quick copying.

- Bug Fixes
  - Adjusted overflow behavior in accordion content and code blocks to prevent clipping, ensuring the copy button and code content remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #247 