### PR TITLE
fix: Pricing features icon alignment

### DIFF
--- a/apps/docs/examples/pricing.tsx
+++ b/apps/docs/examples/pricing.tsx
@@ -115,7 +115,7 @@ const Example = () => {
                 <CardDescription>
                   <p>{plan.description}</p>
                   {typeof plan.price[frequency as keyof typeof plan.price] ===
-                    "number" ? (
+                  "number" ? (
                     <NumberFlow
                       className="font-medium text-foreground"
                       format={{
@@ -126,7 +126,7 @@ const Example = () => {
                       suffix={`/month, billed ${frequency}.`}
                       value={
                         plan.price[
-                        frequency as keyof typeof plan.price
+                          frequency as keyof typeof plan.price
                         ] as number
                       }
                     />


### PR DESCRIPTION
## Description

Fixes icon shrinking and alignment within pricing block when the feature text wraps to two lines.

## Related Issues

Closes #<issue_number>

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

| BEFORE | AFTER |
|--------|--------|
| <img width="846" height="408" alt="Screenshot 2025-09-29 at 4 10 49 PM" src="https://github.com/user-attachments/assets/5b5154c7-17b9-4b63-9977-5ad9b5869e42" /> | <img width="824" height="432" alt="Screenshot 2025-09-29 at 4 09 26 PM" src="https://github.com/user-attachments/assets/9565b37d-98f2-4213-b0df-529336647af5" /> | 

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated pricing example feature rows to remove vertical centering, improving spacing and legibility.
  * Adjusted check icon sizing to maintain consistent alignment and prevent stretching across layouts and browsers.

* **Documentation**
  * Refreshed the pricing example visuals for clearer feature lists and more consistent presentation across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->