### PR TITLE
docs: replace shields.io badges with shieldcn badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Kibo UI
 
 <div>
-  <img src="https://img.shields.io/npm/dy/kibo-ui" alt="" />
-  <img src="https://img.shields.io/npm/v/kibo-ui" alt="" />
-  <img src="https://img.shields.io/github/license/shadcnblocks/kibo" alt="" />
+  <img src="https://shieldcn.dev/npm/dy/kibo-ui.svg?variant=branded" alt="npm downloads" />
+  <img src="https://shieldcn.dev/npm/v/kibo-ui.svg?variant=branded" alt="npm version" />
+  <img src="https://shieldcn.dev/github/license/shadcnblocks/kibo.svg?variant=branded" alt="license" />
 </div>
 
 ## Overview


### PR DESCRIPTION
## Summary

Replaces all 3 shields.io badges in the README with [shieldcn](https://shieldcn.dev) badges — a shadcn/ui-styled badge service that renders as actual Button components via Satori. Felt like a natural fit for a shadcn/ui component library. 🙂

### Before (shields.io)
![before](https://img.shields.io/npm/dy/kibo-ui)
![before](https://img.shields.io/npm/v/kibo-ui)
![before](https://img.shields.io/github/license/shadcnblocks/kibo)

### After (shieldcn)
![after](https://shieldcn.dev/npm/dy/kibo-ui.svg?variant=branded)
![after](https://shieldcn.dev/npm/v/kibo-ui.svg?variant=branded)
![after](https://shieldcn.dev/github/license/shadcnblocks/kibo.svg?variant=branded)

### What changed

| Badge | Old (shields.io) | New (shieldcn) |
|-------|-------------------|----------------|
| npm Downloads | `img.shields.io/npm/dy/kibo-ui` | `shieldcn.dev/npm/dy/kibo-ui.svg` |
| npm Version | `img.shields.io/npm/v/kibo-ui` | `shieldcn.dev/npm/v/kibo-ui.svg` |
| License | `img.shields.io/github/license/shadcnblocks/kibo` | `shieldcn.dev/github/license/shadcnblocks/kibo.svg` |

### Why shieldcn?

- **shadcn/ui design language** — badges render as actual Button components with proper design tokens (seemed fitting for Kibo UI!)
- **Branded variant** — auto-resolves SimpleIcons colors (npm red, GitHub dark) with WCAG-compliant contrast
- **Live data** — downloads, version, and license update automatically via API providers
- **Open source** — [github.com/jal-co/shieldcn](https://github.com/jal-co/shieldcn) (MIT)

Also added proper alt text to each badge image tag.